### PR TITLE
Bugfix errors unmarshalling tax id

### DIFF
--- a/invdendpoint/taxes.go
+++ b/invdendpoint/taxes.go
@@ -2,7 +2,7 @@ package invdendpoint
 
 //Represents the application of tax to an invoice or line item.
 type Tax struct {
-	Id      int64   `json:"id,omitempty"`       //The tax’s unique ID
-	Amount  float64 `json:"amount,omitempty"`   //Tax amount
-	TaxRate Rate    `json:"tax_rate,omitempty"` //Tax Rate the tax was computed from, if any
+	Id      int64   `json:"id,string,omitempty"` //The tax’s unique ID
+	Amount  float64 `json:"amount,omitempty"`    //Tax amount
+	TaxRate Rate    `json:"tax_rate,omitempty"`  //Tax Rate the tax was computed from, if any
 }


### PR DESCRIPTION
Changes related to those discussed with Invoiced regarding line item unmarshalling errors, to address errors we've been encountering trying to retrieve Subscription objects