### PR TITLE
Address / fix errors unmarshalling `catalog_item`

### DIFF
--- a/invdendpoint/lineitems.go
+++ b/invdendpoint/lineitems.go
@@ -2,7 +2,7 @@ package invdendpoint
 
 type LineItem struct {
 	Id           int64                  `json:"id,omitempty"`           //The line item’s unique ID
-	CatalogItem  CatalogItem            `json:"catalog_item,omitempty"` //Optional Catalog Item ID. Fills the line item with the name and pricing of the Catalog Item.
+	CatalogItem  string                 `json:"catalog_item,omitempty"` //Optional Catalog Item ID. Fills the line item with the name and pricing of the Catalog Item.
 	Type         string                 `json:"type,omitempty"`         //Optional line item type. Used to group line items by type in reporting
 	Name         string                 `json:"name,omitempty"`         //Title
 	Description  string                 `json:"description,omitempty"`  //Optional description

--- a/invdendpoint/subscriptionaddons.go
+++ b/invdendpoint/subscriptionaddons.go
@@ -1,9 +1,9 @@
 package invdendpoint
 
 type SubscriptionAddon struct {
-	Id          int64       `json:"id,omitempty"`           //The subscription’s unique ID
-	CatalogItem CatalogItem `json:"catalog_item,omitempty"` //Catalog Item ID
-	Plan        string      `json:"plan,omitempty"`         //The Subscription's Plan ID
-	Quantity    int64       `json:"quantity,omitempty"`     //Quantity
-	CreatedAt   int64       `json:"created_at,omitempty"`   //Timestamp when created
+	Id          int64  `json:"id,omitempty"`           //The subscription’s unique ID
+	CatalogItem string `json:"catalog_item,omitempty"` //Catalog Item ID
+	Plan        string `json:"plan,omitempty"`         //The Subscription's Plan ID
+	Quantity    int64  `json:"quantity,omitempty"`     //Quantity
+	CreatedAt   int64  `json:"created_at,omitempty"`   //Timestamp when created
 }

--- a/invoice.go
+++ b/invoice.go
@@ -2,10 +2,9 @@ package invdapi
 
 import (
 	"fmt"
+
 	"github.com/ActiveState/invoiced-go/invdendpoint"
 )
-
-const defaultExpandInvoice = "items.catalog_item"
 
 type Invoice struct {
 	*Connection
@@ -85,12 +84,6 @@ func (c *Invoice) Retrieve(id int64) (*Invoice, error) {
 		endPoint = addIncludeToEndPoint(endPoint, "updated_at")
 	}
 
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandInvoice)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
-
 	custEndPoint := new(invdendpoint.Invoice)
 
 	invoice := &Invoice{c.Connection, custEndPoint, c.IncludeUpdatedAt}
@@ -112,12 +105,6 @@ func (c *Invoice) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) 
 	if c.IncludeUpdatedAt {
 		endPoint = addIncludeToEndPoint(endPoint, "updated_at")
 	}
-
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandInvoice)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
 
 	invoices := make(Invoices, 0)
 
@@ -151,12 +138,6 @@ func (c *Invoice) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (In
 	if c.IncludeUpdatedAt {
 		endPoint = addIncludeToEndPoint(endPoint, "updated_at")
 	}
-
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandInvoice)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
 
 	invoices := make(Invoices, 0)
 

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -4,8 +4,6 @@ import (
 	"github.com/ActiveState/invoiced-go/invdendpoint"
 )
 
-const defaultExpandSubscription = "addons.catalog_item"
-
 type Subscription struct {
 	*Connection
 	*invdendpoint.Subscription
@@ -79,12 +77,6 @@ func (c *Subscription) Save() error {
 func (c *Subscription) Retrieve(id int64) (*Subscription, error) {
 	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint), id)
 
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandSubscription)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
-
 	custEndPoint := new(invdendpoint.Subscription)
 
 	subscription := &Subscription{c.Connection, custEndPoint}
@@ -102,12 +94,6 @@ func (c *Subscription) Retrieve(id int64) (*Subscription, error) {
 func (c *Subscription) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Subscriptions, error) {
 	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
-
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandSubscription)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
 
 	subscriptions := make(Subscriptions, 0)
 
@@ -138,12 +124,6 @@ NEXT:
 func (c *Subscription) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Subscriptions, string, error) {
 	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
-
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandSubscription)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
 
 	subscriptions := make(Subscriptions, 0)
 


### PR DESCRIPTION
Changes discussed with Invoiced to address errors we've been encountering trying to retrieve and save Invoice objects