### PR TITLE
Bugfix/replace tax object with rate

### DIFF
--- a/invdendpoint/catalogitem.go
+++ b/invdendpoint/catalogitem.go
@@ -10,7 +10,7 @@ type CatalogItem struct {
 	UnitCost     float64                `json:"unit_cost,omitempty"`    //First address line
 	Description  string                 `json:"description,omitempty"`  //Optional description
 	Type         string                 `json:"service,omitempty"`      //Optional line item type. Used to group line items by type in reporting
-	Taxes        []Tax                  `json:"taxes,omitempty"`        //Collection of Tax Rate Objects
+	Taxes        []Rate                 `json:"taxes,omitempty"`        //Collection of Tax Rate Objects
 	Discountable bool                   `json:"discountable,omitempty"` //Excludes amount from discounts when false
 	Taxable      bool                   `json:"taxable,omitempty"`      //Excludes amount from taxes when false
 	CreatedAt    int64                  `json:"created_at,omitempty"`   //Timestamp when created

--- a/invdendpoint/subscriptions.go
+++ b/invdendpoint/subscriptions.go
@@ -9,24 +9,24 @@ const SubscriptionsEndPoint = "/subscriptions"
 type Subscriptions []Subscription
 
 type Subscription struct {
-	Id          int64                  `json:"id,omitempty"`           //The subscription’s unique ID
-	Customer    int64                  `json:"customer,omitempty"`     //Associated Customer
-	Plan        string                 `json:"plan,omitempty"`         //Plan ID
-	StartDate   int64                  `json:"start_date,omitempty"`   //Timestamp subscription starts (or started)
-	Quantity    int64                  `json:"quantity,omitempty"`     //Plan quantity. Defaults to 1
-	Cycles      int64                  `json:"cycles,omitempty"`       //Number of billing cycles the subscription runs for, when null runs until canceled (default).
-	PeriodStart int64                  `json:"period_start,omitempty"` //Start of the current billing period
-	PeriodEnd   int64                  `json:"period_end,omitempty"`   //End of the current billing period
-	Status      string                 `json:"status,omitempty"`       //Subscription status, one of not_started, active, past_due, finished
-	Addons      []SubscriptionAddon    `json:"addons,omitempty"`       //Collection of Subscription Addons
-	Discounts   []Discount             `json:"discount,omitempty"`     //Collection of Coupon IDs
-	Taxes       []Tax                  `json:"taxes,omitempty"`        //Collection of Tax Rate IDs
-	Url         string                 `json:"url,omitempty"`          //URL to manage the subscription in the billing portal
-	CreatedAt   int64                  `json:"created_at,omitempty"`   //Timestamp when created
-	MetaData    map[string]interface{} `json:"metadata,omitempty"`     //A hash of key/value pairs that can store additional information about this object.
-	Prorate bool `json:"prorate,omitempty"`
-	ContractRenewalMode string `json:"contract_renewal_mode,omitempty"`
-	ShipTo      struct {
+	Id                  int64                  `json:"id,omitempty"`           //The subscription’s unique ID
+	Customer            int64                  `json:"customer,omitempty"`     //Associated Customer
+	Plan                string                 `json:"plan,omitempty"`         //Plan ID
+	StartDate           int64                  `json:"start_date,omitempty"`   //Timestamp subscription starts (or started)
+	Quantity            int64                  `json:"quantity,omitempty"`     //Plan quantity. Defaults to 1
+	Cycles              int64                  `json:"cycles,omitempty"`       //Number of billing cycles the subscription runs for, when null runs until canceled (default).
+	PeriodStart         int64                  `json:"period_start,omitempty"` //Start of the current billing period
+	PeriodEnd           int64                  `json:"period_end,omitempty"`   //End of the current billing period
+	Status              string                 `json:"status,omitempty"`       //Subscription status, one of not_started, active, past_due, finished
+	Addons              []SubscriptionAddon    `json:"addons,omitempty"`       //Collection of Subscription Addons
+	Discounts           []Discount             `json:"discount,omitempty"`     //Collection of Coupon IDs
+	Taxes               []Rate                 `json:"taxes,omitempty"`        //Collection of Tax Rate IDs
+	Url                 string                 `json:"url,omitempty"`          //URL to manage the subscription in the billing portal
+	CreatedAt           int64                  `json:"created_at,omitempty"`   //Timestamp when created
+	MetaData            map[string]interface{} `json:"metadata,omitempty"`     //A hash of key/value pairs that can store additional information about this object.
+	Prorate             bool                   `json:"prorate,omitempty"`
+	ContractRenewalMode string                 `json:"contract_renewal_mode,omitempty"`
+	ShipTo              struct {
 		Address1    string `json:"address1,omitempty"`
 		Address2    string `json:"address2,omitempty"`
 		AttentionTo string `json:"attention_to,omitempty"`

--- a/invdendpoint/taxes.go
+++ b/invdendpoint/taxes.go
@@ -2,7 +2,7 @@ package invdendpoint
 
 //Represents the application of tax to an invoice or line item.
 type Tax struct {
-	Id      int64   `json:"id,string,omitempty"` //The tax’s unique ID
-	Amount  float64 `json:"amount,omitempty"`    //Tax amount
-	TaxRate Rate    `json:"tax_rate,omitempty"`  //Tax Rate the tax was computed from, if any
+	Id      int64   `json:"id,omitempty"`       //The tax’s unique ID
+	Amount  float64 `json:"amount,omitempty"`   //Tax amount
+	TaxRate Rate    `json:"tax_rate,omitempty"` //Tax Rate the tax was computed from, if any
 }


### PR DESCRIPTION
- Revert 'string' qualifier. It was a red-herring. The issue stemmed from the API trying to make Rate objects into Tax objects (the Rate object IDs _are_ strings)
- Swap out the _wrong_ data structures with the _right_ ones. According to Invoiced.