### PR TITLE
Updates to support charging through the API

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -2,8 +2,9 @@ package invdapi
 
 import (
 	"errors"
-	"github.com/ActiveState/invoiced-go/invdendpoint"
 	"strconv"
+
+	"github.com/ActiveState/invoiced-go/invdendpoint"
 )
 
 type Customer struct {
@@ -36,7 +37,7 @@ func (c *Customer) Create(customer *Customer) (*Customer, error) {
 	endPoint := c.MakeEndPointURL(invdendpoint.CustomersEndPoint)
 	custResp := new(Customer)
 
-	apiErr := c.create(endPoint, customer, custResp)
+	apiErr := c.create(endPoint, customer.SaveableCustomer, custResp)
 
 	if apiErr != nil {
 		return nil, apiErr
@@ -64,7 +65,7 @@ func (c *Customer) Delete() error {
 func (c *Customer) Save() error {
 	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id)
 	custResp := new(Customer)
-	apiErr := c.update(endPoint, c, custResp)
+	apiErr := c.update(endPoint, c.SaveableCustomer, custResp)
 
 	if apiErr != nil {
 		return apiErr

--- a/customer_test.go
+++ b/customer_test.go
@@ -2,12 +2,13 @@ package invdapi
 
 import (
 	"encoding/json"
-	"github.com/ActiveState/invoiced-go/invdendpoint"
-	"github.com/ActiveState/invoiced-go/invdmockserver"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/ActiveState/invoiced-go/invdendpoint"
+	"github.com/ActiveState/invoiced-go/invdmockserver"
 )
 
 type customerMetaData map[string]interface{}
@@ -26,7 +27,7 @@ func TestCustomerMetaData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(b) != `{"id":34,"metadata":{"integration_name":"QBO"}}` {
+	if string(b) != `{"metadata":{"integration_name":"QBO"},"id":34}` {
 		t.Fatal("Json is wrong", "right json =>", string(b))
 	}
 

--- a/invdendpoint/customers.go
+++ b/invdendpoint/customers.go
@@ -41,7 +41,7 @@ type SaveableCustomer struct {
 	Phone        string                 `json:"phone,omitempty"`         //Phone #
 	Notes        string                 `json:"notes,omitempty"`         //Private customer notes
 	MetaData     map[string]interface{} `json:"metadata,omitempty"`      //A hash of key/value pairs that can store additional information about this object.
-	StripeToken  string                 `json:"stripe_token",omitempty"` //A Stripe credit card token to set as the customer's default payment source
+	StripeToken  string                 `json:"stripe_token,omitempty"`  //A Stripe credit card token to set as the customer's default payment source
 }
 
 type PaymentSource struct {

--- a/invdendpoint/customers.go
+++ b/invdendpoint/customers.go
@@ -36,6 +36,7 @@ type Customer struct {
 	StatementPdfUrl    string                 `json:"statement_pdf_url,omitempty"` //URL to download the latest account statement
 	CreatedAt          int64                  `json:"created_at,omitempty"`        //Timestamp when created
 	MetaData           map[string]interface{} `json:"metadata,omitempty"`          //A hash of key/value pairs that can store additional information about this object.
+	StripeToken        string                 `json:"stripe_token",omitempty"`     //A Stripe credit card token to set as the customer's default payment source
 }
 
 type PaymentSource struct {

--- a/invdendpoint/customers.go
+++ b/invdendpoint/customers.go
@@ -12,31 +12,36 @@ type Customers []Customer
 //Customers represent the entity you are billing, whether this is an organization or a individual. Each customer has a collection mode, automatic or manual. In automatic collection mode any invoices will be charged to your customer’s payment source. Currently we only support debit and credit cards as payment sources.
 //Conversely, manual collection mode will let your customers pay each invoice issued with one of the payment methods you accept.
 type Customer struct {
-	Id                 int64                  `json:"id,omitempty"`                //The customer’s unique ID
-	Name               string                 `json:"name,omitempty"`              //Customer name
-	Number             string                 `json:"number,omitempty"`            //A unique ID to help tie your customer to your external systems
-	Email              string                 `json:"email,omitempty"`             //Email address
-	CollectionMode     string                 `json:"collection_mode,omitempty"`   //Invoice collection mode, auto or manual
-	PaymentTerms       string                 `json:"payment_terms,omitempty"`     //Payment terms used for manual collection mode, i.e. “NET 30”
-	PaymentSourceRAW   json.RawMessage        `json:"payment_source,omitempty"`    //Holds the raw payment json information for later parsing
-	PaymentSource      *PaymentSource         `json:"-"`                           //Customer’s payment source, if attached
-	PaymentSourceReady bool                   `json:"-"`                           //If true than run UnbundlePaymentSource()
-	Taxes              []Rate                 `json:"taxes,omitempty"`             //Collection of Tax Rate IDs
-	Type               string                 `json:"type,omitempty"`              //Organization type, company or person
-	AttentionTo        string                 `json:"attention_to,omitempty"`      //Used for ATTN: address line if company
-	Address1           string                 `json:"address1,omitempty"`          //First address line
-	Address2           string                 `json:"address2,omitempty"`          //Optional second address line
-	City               string                 `json:"city,omitempty"`              //City
-	State              string                 `json:"state,omitempty"`             //State or province
-	PostalCode         string                 `json:"postal_code,omitempty"`       //Zip or postal code
-	Country            string                 `json:"country,omitempty"`           //Two-letter ISO code
-	TaxID              string                 `json:"taxid,omitempty"`             //Tax ID to be displayed on documents
-	Phone              string                 `json:"phone,omitempty"`             //Phone #
-	Notes              string                 `json:"notes,omitempty"`             //Private customer notes
-	StatementPdfUrl    string                 `json:"statement_pdf_url,omitempty"` //URL to download the latest account statement
-	CreatedAt          int64                  `json:"created_at,omitempty"`        //Timestamp when created
-	MetaData           map[string]interface{} `json:"metadata,omitempty"`          //A hash of key/value pairs that can store additional information about this object.
-	StripeToken        string                 `json:"stripe_token",omitempty"`     //A Stripe credit card token to set as the customer's default payment source
+	SaveableCustomer
+	Id                 int64           `json:"id,omitempty"`                //The customer’s unique ID
+	CollectionMode     string          `json:"collection_mode,omitempty"`   //Invoice collection mode, auto or manual
+	PaymentSourceRAW   json.RawMessage `json:"payment_source,omitempty"`    //Holds the raw payment json information for later parsing
+	PaymentSource      *PaymentSource  `json:"-"`                           //Customer’s payment source, if attached
+	PaymentSourceReady bool            `json:"-"`                           //If true than run UnbundlePaymentSource()
+	StatementPdfUrl    string          `json:"statement_pdf_url,omitempty"` //URL to download the latest account statement
+	CreatedAt          int64           `json:"created_at,omitempty"`        //Timestamp when created
+}
+
+//SaveableCustomer includes the subset of Customer fields which are valid for customer creation/update requests
+type SaveableCustomer struct {
+	Name         string                 `json:"name,omitempty"`          //Customer name
+	Number       string                 `json:"number,omitempty"`        //A unique ID to help tie your customer to your external systems
+	Email        string                 `json:"email,omitempty"`         //Email address
+	PaymentTerms string                 `json:"payment_terms,omitempty"` //Payment terms used for manual collection mode, i.e. “NET 30”
+	Taxes        []Rate                 `json:"taxes,omitempty"`         //Collection of Tax Rate IDs
+	Type         string                 `json:"type,omitempty"`          //Organization type, company or person
+	AttentionTo  string                 `json:"attention_to,omitempty"`  //Used for ATTN: address line if company
+	Address1     string                 `json:"address1,omitempty"`      //First address line
+	Address2     string                 `json:"address2,omitempty"`      //Optional second address line
+	City         string                 `json:"city,omitempty"`          //City
+	State        string                 `json:"state,omitempty"`         //State or province
+	PostalCode   string                 `json:"postal_code,omitempty"`   //Zip or postal code
+	Country      string                 `json:"country,omitempty"`       //Two-letter ISO code
+	TaxID        string                 `json:"taxid,omitempty"`         //Tax ID to be displayed on documents
+	Phone        string                 `json:"phone,omitempty"`         //Phone #
+	Notes        string                 `json:"notes,omitempty"`         //Private customer notes
+	MetaData     map[string]interface{} `json:"metadata,omitempty"`      //A hash of key/value pairs that can store additional information about this object.
+	StripeToken  string                 `json:"stripe_token",omitempty"` //A Stripe credit card token to set as the customer's default payment source
 }
 
 type PaymentSource struct {

--- a/invdendpoint/invoices_test.go
+++ b/invdendpoint/invoices_test.go
@@ -43,21 +43,7 @@ func TestUnMarshalInvoiceObject(t *testing.T) {
     },
     {
       "id": 8,
-      "catalog_item": {
-  "id": "delivery",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
+      "catalog_item": "delivery",
       "type": "service",
       "name": "Delivery",
       "description": "",

--- a/invdendpoint/lineitems_test.go
+++ b/invdendpoint/lineitems_test.go
@@ -8,21 +8,7 @@ import (
 func TestUnMarshalLineItemObject(t *testing.T) {
 	s := `{
   "id": 8,
-  "catalog_item": {
-  "id": "delivery",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
+  "catalog_item": "delivery",
   "type": "service",
   "name": "Delivery",
   "description": "",
@@ -72,7 +58,7 @@ func TestUnMarshalLineItemObject(t *testing.T) {
 		t.Fatal("Item 1 has incorrect taxable")
 	}
 
-	if so.CatalogItem.Id != "delivery" {
+	if so.CatalogItem != "delivery" {
 		t.Fatal("Item 1 has incorrect catalogitem id")
 	}
 

--- a/invdendpoint/subscriptionaddons_test.go
+++ b/invdendpoint/subscriptionaddons_test.go
@@ -8,21 +8,7 @@ import (
 func TestUnMarshalSubscriptionAddonObject(t *testing.T) {
 	s := `{
     "id": 3,
-    "catalog_item": {
-  "id": "delivery",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
+    "catalog_item": "delivery",
     "plan" : "test-plan",
     "quantity": 11,
     "created_at": 1420391704

--- a/invdendpoint/subscriptions.go
+++ b/invdendpoint/subscriptions.go
@@ -9,21 +9,24 @@ const SubscriptionsEndPoint = "/subscriptions"
 type Subscriptions []Subscription
 
 type Subscription struct {
-	Id                  int64                  `json:"id,omitempty"`           //The subscription’s unique ID
-	Customer            int64                  `json:"customer,omitempty"`     //Associated Customer
-	Plan                string                 `json:"plan,omitempty"`         //Plan ID
-	StartDate           int64                  `json:"start_date,omitempty"`   //Timestamp subscription starts (or started)
-	Quantity            int64                  `json:"quantity,omitempty"`     //Plan quantity. Defaults to 1
-	Cycles              int64                  `json:"cycles,omitempty"`       //Number of billing cycles the subscription runs for, when null runs until canceled (default).
-	PeriodStart         int64                  `json:"period_start,omitempty"` //Start of the current billing period
-	PeriodEnd           int64                  `json:"period_end,omitempty"`   //End of the current billing period
-	Status              string                 `json:"status,omitempty"`       //Subscription status, one of not_started, active, past_due, finished
-	Addons              []SubscriptionAddon    `json:"addons,omitempty"`       //Collection of Subscription Addons
-	Discounts           []Discount             `json:"discount,omitempty"`     //Collection of Coupon IDs
-	Taxes               []Rate                 `json:"taxes,omitempty"`        //Collection of Tax Rate IDs
-	Url                 string                 `json:"url,omitempty"`          //URL to manage the subscription in the billing portal
-	CreatedAt           int64                  `json:"created_at,omitempty"`   //Timestamp when created
-	MetaData            map[string]interface{} `json:"metadata,omitempty"`     //A hash of key/value pairs that can store additional information about this object.
+	Id                  int64                  `json:"id,omitempty"`                    //The subscription’s unique ID
+	Customer            int64                  `json:"customer,omitempty"`              //Associated Customer
+	Plan                string                 `json:"plan,omitempty"`                  //Plan ID
+	StartDate           int64                  `json:"start_date,omitempty"`            //Timestamp subscription starts (or started)
+	Quantity            int64                  `json:"quantity,omitempty"`              //Plan quantity. Defaults to 1
+	Cycles              int64                  `json:"cycles,omitempty"`                //Number of billing cycles the subscription runs for, when null runs until canceled (default).
+	PeriodStart         int64                  `json:"period_start,omitempty"`          //Start of the current billing period
+	PeriodEnd           int64                  `json:"period_end,omitempty"`            //End of the current billing period
+	ContractPeriodStart int64                  `json:"contract_period_start,omitempty"` //Start of current contract period
+	ContractPeriodEnd   int64                  `json:"contract_period_end,omitempty"`   //End of current contract period
+	RenewsNext          int64                  `json:"renews_next,omitempty"`           //Date of next automatic renewal
+	Status              string                 `json:"status,omitempty"`                //Subscription status, one of not_started, active, past_due, finished
+	Addons              []SubscriptionAddon    `json:"addons,omitempty"`                //Collection of Subscription Addons
+	Discounts           []Discount             `json:"discount,omitempty"`              //Collection of Coupon IDs
+	Taxes               []Rate                 `json:"taxes,omitempty"`                 //Collection of Tax Rate IDs
+	Url                 string                 `json:"url,omitempty"`                   //URL to manage the subscription in the billing portal
+	CreatedAt           int64                  `json:"created_at,omitempty"`            //Timestamp when created
+	MetaData            map[string]interface{} `json:"metadata,omitempty"`              //A hash of key/value pairs that can store additional information about this object.
 	Prorate             bool                   `json:"prorate,omitempty"`
 	ContractRenewalMode string                 `json:"contract_renewal_mode,omitempty"`
 	ShipTo              struct {

--- a/invdendpoint/subscriptions_test.go
+++ b/invdendpoint/subscriptions_test.go
@@ -19,21 +19,7 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
     "addons": [
         {
             "id": 3,
-            "catalog_item": {
-  "id": "ipad-license",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
+            "catalog_item": "ipad-license",
             "quantity": 11,
             "created_at": 1420391704
         }
@@ -101,7 +87,7 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
 		t.Fatal("Subscription Addon 0 has incorrect status")
 	}
 
-	if so.Addons[0].CatalogItem.Id != "ipad-license" {
+	if so.Addons[0].CatalogItem != "ipad-license" {
 		t.Fatal("Subscription Addon CatalogItem 0  has incorrect status")
 	}
 
@@ -125,7 +111,6 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
 	if so.ContractRenewalMode != "manual" {
 		t.Fatal("Subscription Ahas incorrect ContractRenewalMode status")
 	}
-
 
 	if so.CreatedAt != 1420391704 {
 		t.Fatal("Subscription CreatedAt is incorrect")
@@ -159,7 +144,7 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
 		t.Fatal("Subscription ShipTo.PostalCode is incorrect")
 	}
 
-	if so.ShipTo.State !=  "TX" {
+	if so.ShipTo.State != "TX" {
 		t.Fatal("Subscription ShipTo.State is incorrect")
 	}
 }


### PR DESCRIPTION
- Adds the `stripe_token` field to the Customer object so we can provide a payment token when creating or editing a Customer.
- Adds the `contract_period_start`, `contract_period_end`, and `renews_next` fields to the Subscription object.
- Currently, calling `Save()` on a Customer retrieved from the API fails on (at least) the `StatementPdfUrl` field, as it's not a valid field to include in a write. Split the type up so we can pass only the writable subset of fields to the create and update calls.