### PR TITLE
Add SetCancelAtPeriodEnd function for updating just that flag on a Subscription

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -141,3 +141,22 @@ func (c *Subscription) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort
 	return subscriptions, nextEndPoint, nil
 
 }
+
+// SetCancelAtPeriodEnd sets the cancel_at_period_end field for the given subscription ID.
+// This is a convenience function to save having to fetch or construct a whole Subscription
+// object in order to call Subscription.Save() on it.
+func (c *Connection) SetCancelAtPeriodEnd(subscriptionID int64, val bool) (*Subscription, error) {
+	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
+	endPoint = makeEndPointSingular(endPoint, subscriptionID)
+
+	type PartialSubscription struct {
+		CancelAtPeriodEnd bool `json:"cancel_at_period_end"`
+	}
+	req := PartialSubscription{
+		CancelAtPeriodEnd: val,
+	}
+	resp := new(invdendpoint.Subscription)
+	err := c.update(endPoint, req, resp)
+	subscription := &Subscription{c, resp}
+	return subscription, err
+}


### PR DESCRIPTION
Two things motivate adding this narrow function:

1. Without this, the only way of updating an existing Subscription is instantiating the `Subscription` struct and calling `Save()` on it; this means first making a potentially extraneous API call to fetch the whole existing record, and increases the odds of fields being accidentally overwritten. My stance is that I never want an update call to set any fields that aren't meant to be changing, because it adds the potential for accidents that otherwise couldn't happen.
2. The `Subscription` struct currently doesn't include the `cancel_at_period_end` field at all, so one change or another to invoiced-go is necessary, and this is more self-contained than updating that struct would be. This is in the context of our fork of invoiced-go already being outdated, and more likely to be replaced (with invoiced-go v2) than brought up to date and maintained.